### PR TITLE
Add my listings dashboard

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -242,6 +242,19 @@ def get_property_by_id(property_id: int) -> Optional[Dict[str, Any]]:
     return _row_to_property(row)
 
 
+def get_properties_by_owner(owner_id: int) -> List[Dict[str, Any]]:
+    conn = _ensure_connection()
+    rows = conn.execute(
+        """
+        SELECT * FROM properties
+        WHERE owner_id = ?
+        ORDER BY datetime(created_at) DESC, id DESC
+        """,
+        (owner_id,),
+    ).fetchall()
+    return [item for row in rows if (item := _row_to_property(row)) is not None]
+
+
 def update_property(
     property_id: int,
     updates: Dict[str, Any],

--- a/backend/app/routers/properties.py
+++ b/backend/app/routers/properties.py
@@ -7,6 +7,7 @@ from app.auth.dependencies import get_current_user_id
 from app.database import (
     create_property as create_property_record,
     delete_property as delete_property_record,
+    get_properties_by_owner,
     get_property_by_id,
     get_user_by_id,
     search_properties as search_properties_db,
@@ -108,6 +109,17 @@ def search_properties_endpoint(
         sort_by=sort_by,
     )
     return [PropertyResponse(**item) for item in results]
+
+
+@router.get("/mine", response_model=List[PropertyResponse])
+def list_my_properties(
+    current_user_id: int = Depends(get_current_user_id),
+) -> List[PropertyResponse]:
+    _validate_user_exists(current_user_id)
+    return [
+        PropertyResponse(**item)
+        for item in get_properties_by_owner(current_user_id)
+    ]
 
 
 @router.get("/{property_id}", response_model=PropertyResponse)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,12 +1,21 @@
 from .user import UserRegister, UserLogin, UserResponse
-from .property import PropertyBase, PropertyCreate, PropertyUpdate, PropertyResponse
+from .property import (
+    PropertyBase,
+    PropertyCategory,
+    PropertyCreate,
+    PropertyResponse,
+    PropertyType,
+    PropertyUpdate,
+)
 
 __all__ = [
     "UserRegister",
     "UserLogin",
     "UserResponse",
     "PropertyBase",
+    "PropertyCategory",
     "PropertyCreate",
+    "PropertyType",
     "PropertyUpdate",
     "PropertyResponse",
 ]

--- a/backend/app/schemas/property.py
+++ b/backend/app/schemas/property.py
@@ -1,18 +1,45 @@
 from datetime import datetime
-from decimal import Decimal
+from enum import Enum
 from typing import Optional
-from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
+
+
+class PropertyType(str, Enum):
+    HOUSE = "house"
+    APARTMENT = "apartment"
+    OFFICE = "office"
+    LAND = "land"
+
+
+class PropertyCategory(str, Enum):
+    SALE = "sale"
+    RENT = "rent"
 
 
 class PropertyBase(BaseModel):
-    title: str
-    description: Optional[str] = None
-    price: Decimal
-    location: str
-    bedrooms: int = Field(..., ge=0)
-    bathrooms: int = Field(..., ge=0)
+    title: str = Field(..., min_length=4, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=2000)
+    location: str = Field(..., min_length=2, max_length=160)
+    price: float = Field(..., ge=100, le=50_000_000)
+    property_type: PropertyType
+    category: PropertyCategory
+    contact_phone: str = Field(..., min_length=6, max_length=40)
+    contact_email: EmailStr
+    num_bedrooms: Optional[int] = Field(default=None, ge=0, le=50)
+    num_bathrooms: Optional[int] = Field(default=None, ge=0, le=50)
+    area_sqm: Optional[float] = Field(default=None, gt=0, le=1_000_000)
+
+    @model_validator(mode="after")
+    def validate_property_rules(self):
+        if self.property_type == PropertyType.LAND:
+            if self.category == PropertyCategory.RENT:
+                raise ValueError("Land properties cannot be rented")
+            if self.num_bedrooms not in (None, 0):
+                raise ValueError("Land properties should not include bedrooms")
+            if self.num_bathrooms not in (None, 0):
+                raise ValueError("Land properties should not include bathrooms")
+        return self
 
 
 class PropertyCreate(PropertyBase):
@@ -20,17 +47,21 @@ class PropertyCreate(PropertyBase):
 
 
 class PropertyUpdate(BaseModel):
-    title: Optional[str] = None
-    description: Optional[str] = None
-    price: Optional[Decimal] = None
-    location: Optional[str] = None
-    bedrooms: Optional[int] = Field(None, ge=0)
-    bathrooms: Optional[int] = Field(None, ge=0)
+    title: Optional[str] = Field(default=None, min_length=4, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=2000)
+    location: Optional[str] = Field(default=None, min_length=2, max_length=160)
+    price: Optional[float] = Field(default=None, ge=100, le=50_000_000)
+    contact_phone: Optional[str] = Field(default=None, min_length=6, max_length=40)
+    contact_email: Optional[EmailStr] = None
+    num_bedrooms: Optional[int] = Field(default=None, ge=0, le=50)
+    num_bathrooms: Optional[int] = Field(default=None, ge=0, le=50)
+    area_sqm: Optional[float] = Field(default=None, gt=0, le=1_000_000)
 
 
 class PropertyResponse(PropertyBase):
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
+    id: int
+    owner_id: int
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/test_business_logic.py
+++ b/backend/tests/test_business_logic.py
@@ -222,6 +222,40 @@ def test_search_filters_and_sorting_can_be_combined(client):
     assert [item["price"] for item in sorted_sale.json()] == [250000, 120000]
 
 
+def test_my_listings_returns_only_authenticated_users_properties(client):
+    register_user(client, "mine-owner@example.com")
+    owner_auth = login_user(client, "mine-owner@example.com")
+    register_user(client, "other-owner@example.com", password="OtherPass123")
+    other_auth = login_user(client, "other-owner@example.com", password="OtherPass123")
+
+    create_property(
+        client,
+        owner_auth["access_token"],
+        title="Owner Apartment",
+        contact_email="mine-owner@example.com",
+    )
+    create_property(
+        client,
+        other_auth["access_token"],
+        title="Other Apartment",
+        contact_email="other-owner@example.com",
+    )
+
+    response = client.get(
+        "/api/properties/mine",
+        headers=auth_headers(owner_auth["access_token"]),
+    )
+
+    assert response.status_code == 200
+    assert [item["title"] for item in response.json()] == ["Owner Apartment"]
+
+
+def test_my_listings_requires_authentication(client):
+    response = client.get("/api/properties/mine")
+
+    assert response.status_code == 401
+
+
 def test_land_rules_are_enforced_on_create_and_update(client):
     register_user(client, "land-owner@example.com")
     auth = login_user(client, "land-owner@example.com")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import HomePage          from "./pages/HomePage";
 import BrowsePage        from "./pages/BrowsePage";
 import AboutPage         from "./pages/AboutPage";
 import ContactPage       from "./pages/ContactPage";
+import MyListingsPage    from "./pages/MyListingsPage";
 import LISTINGS          from "./data/listings";
 
 const API_BASE = process.env.REACT_APP_API_BASE || "http://localhost:8000/api";
@@ -130,6 +131,8 @@ export default function App() {
         return <AboutPage />;
       case "contact":
         return <ContactPage />;
+      case "my-listings":
+        return <MyListingsPage authToken={authToken} onView={setViewListing} />;
       default:
         return <HomePage listings={listings} onSearch={handleSearch} onView={setViewListing} />;
     }
@@ -141,6 +144,7 @@ export default function App() {
         onNav={navigate} activePage={page} user={user}
         onAuth={m => setAuthModal(m)} onLogout={() => { setUser(null); setAuthToken(""); }}
         onListProperty={() => setShowList(true)}
+        onMyListings={() => navigate("my-listings")}
       />
 
       <main style={{ minHeight: "calc(100vh - 68px - 260px)" }}>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -2,15 +2,15 @@ import { useState, useRef, useEffect } from "react";
 import ValoraLogo from "./ValoraLogo";
 
 const BUY_ITEMS  = [
-  { label: "Houses"     },
-  { label: "Apartments" },
-  { label: "Offices"    },
-  { label: "Land"       },
+  { label: "Houses",     value: "house"     },
+  { label: "Apartments", value: "apartment" },
+  { label: "Offices",    value: "office"    },
+  { label: "Land",       value: "land"      },
 ];
 const RENT_ITEMS = [
-  { label: "Houses"     },
-  { label: "Apartments" },
-  { label: "Offices"    },
+  { label: "Houses",     value: "house"     },
+  { label: "Apartments", value: "apartment" },
+  { label: "Offices",    value: "office"    },
 ];
 
 function NavBtn({ label, active, onClick, children, ...props }) {
@@ -25,7 +25,7 @@ function NavBtn({ label, active, onClick, children, ...props }) {
   );
 }
 
-export default function Navbar({ onNav, activePage, user, onAuth, onLogout, onListProperty }) {
+export default function Navbar({ onNav, activePage, user, onAuth, onLogout, onListProperty, onMyListings }) {
   const [buyOpen,     setBuyOpen]     = useState(false);
   const [rentOpen,    setRentOpen]    = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
@@ -60,7 +60,7 @@ export default function Navbar({ onNav, activePage, user, onAuth, onLogout, onLi
               <div className="nav-dropdown" onMouseLeave={() => setBuyOpen(false)}>
                 {BUY_ITEMS.map(it => (
                   <button key={it.label} className="nav-dropdown-item"
-                    onClick={() => { onNav("buy", it.label.toLowerCase()); setBuyOpen(false); }}>
+                    onClick={() => { onNav("buy", it.value); setBuyOpen(false); }}>
                     {it.label}
                   </button>
                 ))}
@@ -77,7 +77,7 @@ export default function Navbar({ onNav, activePage, user, onAuth, onLogout, onLi
               <div className="nav-dropdown" onMouseLeave={() => setRentOpen(false)}>
                 {RENT_ITEMS.map(it => (
                   <button key={it.label} className="nav-dropdown-item"
-                    onClick={() => { onNav("rent", it.label.toLowerCase()); setRentOpen(false); }}>
+                    onClick={() => { onNav("rent", it.value); setRentOpen(false); }}>
                     {it.label}
                   </button>
                 ))}
@@ -99,6 +99,7 @@ export default function Navbar({ onNav, activePage, user, onAuth, onLogout, onLi
               {profileOpen && (
                 <div className="nav-dropdown" style={{ right: 0, left: "auto", transform: "none", minWidth: 190 }}>
                   <button className="nav-dropdown-item" style={{ fontWeight: 700, cursor: "default" }}>{user.name}</button>
+                  <button className="nav-dropdown-item" onClick={() => { onMyListings(); setProfileOpen(false); }}>My Listings</button>
                   <button className="nav-dropdown-item" onClick={() => { onListProperty(); setProfileOpen(false); }}>List a Property</button>
                   <button className="nav-dropdown-item" style={{ color: "#c00" }} onClick={() => { onLogout(); setProfileOpen(false); }}>Sign Out</button>
                 </div>

--- a/frontend/src/pages/MyListingsPage.jsx
+++ b/frontend/src/pages/MyListingsPage.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import ListingCard from "../components/ListingCard";
+import C from "../constants/colors";
+
+const API_BASE = process.env.REACT_APP_API_BASE || "http://localhost:8000/api";
+
+function mapApiProperty(property) {
+  return {
+    id: `api-${property.id}`,
+    apiId: property.id,
+    listing: property.category === "rent" ? "rent" : "buy",
+    type: property.property_type,
+    name: property.title,
+    location: property.location,
+    price: property.price,
+    beds: property.num_bedrooms || 0,
+    baths: property.num_bathrooms || 0,
+    sqft: property.area_sqm || 0,
+    seller: property.contact_email,
+    phone: property.contact_phone,
+    description: property.description || "",
+    img: property.image_url || "https://images.unsplash.com/photo-1560518883-ce09059eeffa?w=600&q=80",
+  };
+}
+
+export default function MyListingsPage({ authToken, onView }) {
+  const [listings, setListings] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [deletingId, setDeletingId] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadMyListings() {
+      setLoading(true);
+      setError("");
+      try {
+        const response = await fetch(`${API_BASE}/properties/mine`, {
+          headers: { Authorization: `Bearer ${authToken}` },
+        });
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(data.detail || "Unable to load your listings");
+        }
+        if (active) setListings(data.map(mapApiProperty));
+      } catch (err) {
+        if (active) setError(err.message || "Unable to load your listings");
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    if (authToken) {
+      loadMyListings();
+    } else {
+      setLoading(false);
+      setError("Sign in to view your listings.");
+    }
+
+    return () => {
+      active = false;
+    };
+  }, [authToken]);
+
+  async function deleteListing(listing) {
+    setDeletingId(listing.apiId);
+    setError("");
+    try {
+      const response = await fetch(`${API_BASE}/properties/${listing.apiId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+      if (!response.ok) {
+        let message = "Unable to delete listing";
+        try {
+          const data = await response.json();
+          message = data.detail || message;
+        } catch (_) {
+          message = "Unable to delete listing";
+        }
+        throw new Error(message);
+      }
+      setListings(prev => prev.filter(item => item.apiId !== listing.apiId));
+    } catch (err) {
+      setError(err.message || "Unable to delete listing");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <section style={{ maxWidth: 1240, margin: "0 auto", padding: "60px 24px" }} className="fade-in">
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 18, alignItems: "flex-end", marginBottom: 32 }}>
+        <div>
+          <h2 className="section-title" style={{ marginBottom: 8 }}>My Listings</h2>
+          <p style={{ color: C.warmGray }}>
+            {loading ? "Loading your properties..." : `${listings.length} owned propert${listings.length === 1 ? "y" : "ies"}`}
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ marginBottom: 24, padding: 16, borderRadius: 8, background: "#fff5f2", color: "#9b2d18" }}>
+          {error}
+        </div>
+      )}
+
+      {!loading && listings.length === 0 && !error && (
+        <div style={{ textAlign: "center", padding: "80px 20px", color: C.warmGray }}>
+          <p style={{ fontSize: 18 }}>You have not listed any properties yet.</p>
+        </div>
+      )}
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))", gap: 24 }}>
+        {listings.map((listing, i) => (
+          <div key={listing.id} className="fade-up" style={{ animationDelay: `${i * 0.05}s` }}>
+            <ListingCard listing={listing} onView={onView} />
+            <button
+              className="btn-outline"
+              style={{ marginTop: 12, width: "100%", color: "#9b2d18", borderColor: "rgba(155, 45, 24, 0.28)" }}
+              disabled={deletingId === listing.apiId}
+              onClick={() => deleteListing(listing)}
+            >
+              {deletingId === listing.apiId ? "Deleting..." : "Delete Listing"}
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Summary
- Fixed property schema/API mismatch
- Added authenticated My Listings endpoint
- Added My Listings dashboard in the frontend
- Added tests for owner-only listing retrieval

Tests
- Backend: 32 passed
- Frontend: npm run build compiled successfully

## Summary by Sourcery

Introduce an authenticated "My Listings" experience across backend and frontend, and align property schemas with the API data model.

New Features:
- Add an authenticated /api/properties/mine endpoint that returns the current user’s properties.
- Add a My Listings dashboard page in the frontend, accessible from the navbar profile menu, showing and allowing deletion of the user’s own listings.

Bug Fixes:
- Align the property schema with the API/database shape, including correct identifiers and field names used by the frontend.

Enhancements:
- Extend property models with typed categories, property types, contact details, and validation rules (including special handling for land listings).
- Update navbar buy/rent dropdown items to use explicit property-type values instead of label-derived values for navigation.

Tests:
- Add backend tests to ensure the My Listings endpoint is authenticated and only returns properties owned by the requesting user.